### PR TITLE
Media tab context

### DIFF
--- a/frontend/src/modules/functional/modules/FileStorage/contexts/MediaTabContextProvider.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/contexts/MediaTabContextProvider.tsx
@@ -3,9 +3,6 @@ import React, { useContext, useState, createContext } from "react";
 interface IMediaTabContext {
   selectedFileId: string | undefined;
   isGalleryModalOpen: boolean;
-}
-
-interface IMediaTabReadOnlyContext {
   openGalleryModal: (newFileId: string) => void;
   closeGalleryModal: () => void;
 }
@@ -13,19 +10,12 @@ interface IMediaTabReadOnlyContext {
 const MediaTabContext = createContext<IMediaTabContext>({
   selectedFileId: undefined,
   isGalleryModalOpen: false,
-});
-
-const MediaTabReadOnlyContext = createContext<IMediaTabReadOnlyContext>({
   openGalleryModal: (newFileId: string) => undefined,
   closeGalleryModal: () => undefined,
 });
 
 export function useMediaTabContext() {
   return useContext(MediaTabContext);
-}
-
-export function useMediaTabContextFunctions() {
-  return useContext(MediaTabReadOnlyContext);
 }
 
 export function MediaTabContextProvider({
@@ -39,7 +29,6 @@ export function MediaTabContextProvider({
   });
 
   const openGalleryModal = (newFileId: string) => {
-    console.log("opening");
     setGalleryModalState({
       isGalleryModalOpen: true,
       selectedFileId: undefined,
@@ -48,18 +37,16 @@ export function MediaTabContextProvider({
 
   const closeGalleryModal = () => {
     setGalleryModalState({
-      isGalleryModalOpen: true,
+      isGalleryModalOpen: false,
       selectedFileId: undefined,
     });
   };
 
   return (
-    <MediaTabContext.Provider value={galleryModalState}>
-      <MediaTabReadOnlyContext.Provider
-        value={{ openGalleryModal, closeGalleryModal }}
-      >
-        {children}
-      </MediaTabReadOnlyContext.Provider>
+    <MediaTabContext.Provider
+      value={{ ...galleryModalState, openGalleryModal, closeGalleryModal }}
+    >
+      {children}
     </MediaTabContext.Provider>
   );
 }

--- a/frontend/src/modules/functional/modules/FileStorage/contexts/MediaTabContextProvider.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/contexts/MediaTabContextProvider.tsx
@@ -1,0 +1,62 @@
+import { SettingsApplicationsOutlined } from "@mui/icons-material";
+import React, { useContext, useState, createContext } from "react";
+
+interface MediaTabContext {
+  selectedFileId: string | undefined;
+  isGalleryModalOpen: boolean;
+}
+
+interface MediaTabReadOnlyContext {
+  openGalleryModal: (newFileId: string) => void;
+  closeGalleryModal: () => void;
+}
+
+const MediaTabContext = createContext<MediaTabContext>({
+  selectedFileId: undefined,
+  isGalleryModalOpen: false,
+});
+
+const MediaTabReadOnlyContext = createContext<MediaTabReadOnlyContext>({
+  openGalleryModal: (newFileId: string) => undefined,
+  closeGalleryModal: () => undefined,
+});
+
+export function useMediaTabContext() {
+  return useContext(MediaTabContext);
+}
+
+export function MediaTabContextProvider({
+  children,
+}: {
+  children: JSX.Element;
+}) {
+  const [selectedFileId, setSelectedFileId] = useState<string | undefined>(
+    undefined
+  );
+  const [isGalleryModalOpen, setIsGalleryModalOpen] = useState<boolean>(false);
+
+  const openGalleryModal = (newFileId: string) => {
+    setSelectedFileId(newFileId);
+    setIsGalleryModalOpen(true);
+  };
+
+  const closeGalleryModal = () => {
+    setIsGalleryModalOpen(false);
+    setSelectedFileId(undefined);
+  };
+
+  return (
+    <MediaTabContext.Provider
+      value={{
+        selectedFileId,
+        isGalleryModalOpen,
+      }}
+    >
+      <MediaTabReadOnlyContext.Provider
+        value={{ openGalleryModal, closeGalleryModal }}
+      >
+        {children}
+      </MediaTabReadOnlyContext.Provider>
+    </MediaTabContext.Provider>
+  );
+}

--- a/frontend/src/modules/functional/modules/FileStorage/contexts/MediaTabContextProvider.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/contexts/MediaTabContextProvider.tsx
@@ -1,21 +1,21 @@
 import React, { useContext, useState, createContext } from "react";
 
-interface MediaTabContext {
+interface IMediaTabContext {
   selectedFileId: string | undefined;
   isGalleryModalOpen: boolean;
 }
 
-interface MediaTabReadOnlyContext {
+interface IMediaTabReadOnlyContext {
   openGalleryModal: (newFileId: string) => void;
   closeGalleryModal: () => void;
 }
 
-const MediaTabContext = createContext<MediaTabContext>({
+const MediaTabContext = createContext<IMediaTabContext>({
   selectedFileId: undefined,
   isGalleryModalOpen: false,
 });
 
-const MediaTabReadOnlyContext = createContext<MediaTabReadOnlyContext>({
+const MediaTabReadOnlyContext = createContext<IMediaTabReadOnlyContext>({
   openGalleryModal: (newFileId: string) => undefined,
   closeGalleryModal: () => undefined,
 });
@@ -33,28 +33,28 @@ export function MediaTabContextProvider({
 }: {
   children: JSX.Element;
 }) {
-  const [selectedFileId, setSelectedFileId] = useState<string | undefined>(
-    undefined
-  );
-  const [isGalleryModalOpen, setIsGalleryModalOpen] = useState<boolean>(false);
+  const [galleryModalState, setGalleryModalState] = useState({
+    isGalleryModalOpen: false,
+    selectedFileId: undefined,
+  });
 
   const openGalleryModal = (newFileId: string) => {
-    setSelectedFileId(newFileId);
-    setIsGalleryModalOpen(true);
+    console.log("opening");
+    setGalleryModalState({
+      isGalleryModalOpen: true,
+      selectedFileId: undefined,
+    });
   };
 
   const closeGalleryModal = () => {
-    setIsGalleryModalOpen(false);
-    setSelectedFileId(undefined);
+    setGalleryModalState({
+      isGalleryModalOpen: true,
+      selectedFileId: undefined,
+    });
   };
 
   return (
-    <MediaTabContext.Provider
-      value={{
-        selectedFileId,
-        isGalleryModalOpen,
-      }}
-    >
+    <MediaTabContext.Provider value={galleryModalState}>
       <MediaTabReadOnlyContext.Provider
         value={{ openGalleryModal, closeGalleryModal }}
       >

--- a/frontend/src/modules/functional/modules/FileStorage/contexts/MediaTabContextProvider.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/contexts/MediaTabContextProvider.tsx
@@ -1,4 +1,3 @@
-import { SettingsApplicationsOutlined } from "@mui/icons-material";
 import React, { useContext, useState, createContext } from "react";
 
 interface MediaTabContext {
@@ -23,6 +22,10 @@ const MediaTabReadOnlyContext = createContext<MediaTabReadOnlyContext>({
 
 export function useMediaTabContext() {
   return useContext(MediaTabContext);
+}
+
+export function useMediaTabContextFunctions() {
+  return useContext(MediaTabReadOnlyContext);
 }
 
 export function MediaTabContextProvider({

--- a/frontend/src/modules/functional/modules/FileStorage/submodules/GalleryModal.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/submodules/GalleryModal.tsx
@@ -28,7 +28,8 @@ function ImagePlaceholder() {
 }
 
 export default function GalleryModal() {
-  const { isGalleryModalOpen } = useMediaTabContext();
+  const state = useMediaTabContext();
+  console.log(state);
 
   const handleDeleteTag = () => {
     console.log("delete tag");
@@ -40,7 +41,7 @@ export default function GalleryModal() {
 
   return (
     <Dialog
-      open={isGalleryModalOpen}
+      open={state.isGalleryModalOpen}
       fullWidth
       maxWidth={"md"}
       PaperProps={{ sx: { p: 0 } }}

--- a/frontend/src/modules/functional/modules/FileStorage/submodules/GalleryModal.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/submodules/GalleryModal.tsx
@@ -28,23 +28,19 @@ function ImagePlaceholder() {
 }
 
 export default function GalleryModal() {
-  const state = useMediaTabContext();
-  console.log(state);
+  const { isGalleryModalOpen, closeGalleryModal } = useMediaTabContext();
 
   const handleDeleteTag = () => {
     console.log("delete tag");
   };
 
-  const handleCloseModal = () => {
-    console.log("closing modal");
-  };
-
   return (
     <Dialog
-      open={state.isGalleryModalOpen}
+      open={isGalleryModalOpen}
       fullWidth
       maxWidth={"md"}
       PaperProps={{ sx: { p: 0 } }}
+      onClose={closeGalleryModal}
     >
       <ImagePlaceholder />
       <Grid
@@ -100,7 +96,7 @@ export default function GalleryModal() {
               <IconButton>
                 <DeleteIcon />
               </IconButton>
-              <IconButton onClick={handleCloseModal}>
+              <IconButton onClick={closeGalleryModal}>
                 <ClearIcon />
               </IconButton>
             </ButtonGroup>

--- a/frontend/src/modules/functional/modules/FileStorage/submodules/GalleryModal.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/submodules/GalleryModal.tsx
@@ -86,9 +86,14 @@ export default function GalleryModal() {
               },
             }}
           >
-            <IconButton>
-              <ArrowBackIcon />
-            </IconButton>
+            <ButtonGroup variant={"contained"}>
+              <IconButton>
+                <ArrowBackIcon />
+              </IconButton>
+              <IconButton>
+                <ArrowForwardIcon />
+              </IconButton>
+            </ButtonGroup>
             <ButtonGroup variant={"contained"}>
               <IconButton>
                 <CheckBoxOutlineBlankIcon />
@@ -100,9 +105,6 @@ export default function GalleryModal() {
                 <ClearIcon />
               </IconButton>
             </ButtonGroup>
-            <IconButton>
-              <ArrowForwardIcon />
-            </IconButton>
           </Stack>
         </Grid>
       </Grid>

--- a/frontend/src/modules/functional/modules/FileStorage/submodules/GalleryModal.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/submodules/GalleryModal.tsx
@@ -9,13 +9,16 @@ import ClearIcon from "@mui/icons-material/Clear";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import Grid from "@mui/material/Grid";
+import CardMedia from "@mui/material/CardMedia";
+import { useMediaTabContext } from "../contexts/MediaTabContextProvider";
 
 const captionStyle = {};
 
 function ImagePlaceholder() {
   return (
-    <div
-      style={{
+    <CardMedia
+      component={"div"}
+      sx={{
         backgroundColor: "red",
         width: "100%",
         aspectRatio: "4/3",
@@ -25,6 +28,8 @@ function ImagePlaceholder() {
 }
 
 export default function GalleryModal() {
+  const { isGalleryModalOpen } = useMediaTabContext();
+
   const handleDeleteTag = () => {
     console.log("delete tag");
   };
@@ -34,7 +39,12 @@ export default function GalleryModal() {
   };
 
   return (
-    <Dialog open={true} fullWidth maxWidth={"md"} PaperProps={{ sx: { p: 0 } }}>
+    <Dialog
+      open={isGalleryModalOpen}
+      fullWidth
+      maxWidth={"md"}
+      PaperProps={{ sx: { p: 0 } }}
+    >
       <ImagePlaceholder />
       <Grid
         container

--- a/frontend/src/modules/functional/modules/FileStorage/submodules/MediaSection.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/submodules/MediaSection.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
 import MediaThumbnail from "./MediaThumbnail";
+import { MediaTabContextProvider } from "../contexts/MediaTabContextProvider";
 
 import Stack from "@mui/material/Stack";
 interface MediaSectionProps {
@@ -10,16 +11,18 @@ interface MediaSectionProps {
 
 // TODO clarify mediaItems type
 const renderMediaThumbnails = (mediaItems: string[]) => {
-  return mediaItems.map((item) => <MediaThumbnail />);
+  return mediaItems.map((item) => <MediaThumbnail key={item} />);
 };
 
 export default function MediaSection({ name }: MediaSectionProps) {
   return (
-    <Stack sx={{ mt: 2, mb: 2 }}>
-      <Typography variant={"h2"}>{name}</Typography>
-      <Grid container spacing={2}>
-        {renderMediaThumbnails(["file 1", "file 2"])}
-      </Grid>
-    </Stack>
+    <MediaTabContextProvider>
+      <Stack sx={{ mt: 2, mb: 2 }}>
+        <Typography variant={"h2"}>{name}</Typography>
+        <Grid container spacing={2}>
+          {renderMediaThumbnails(["file 1", "file 2"])}
+        </Grid>
+      </Stack>
+    </MediaTabContextProvider>
   );
 }

--- a/frontend/src/modules/functional/modules/FileStorage/submodules/MediaSection.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/submodules/MediaSection.tsx
@@ -16,13 +16,11 @@ const renderMediaThumbnails = (mediaItems: string[]) => {
 
 export default function MediaSection({ name }: MediaSectionProps) {
   return (
-    <MediaTabContextProvider>
-      <Stack sx={{ mt: 2, mb: 2 }}>
-        <Typography variant={"h2"}>{name}</Typography>
-        <Grid container spacing={2}>
-          {renderMediaThumbnails(["file 1", "file 2"])}
-        </Grid>
-      </Stack>
-    </MediaTabContextProvider>
+    <Stack sx={{ mt: 2, mb: 2 }}>
+      <Typography variant={"h2"}>{name}</Typography>
+      <Grid container spacing={2}>
+        {renderMediaThumbnails(["file 1", "file 2"])}
+      </Grid>
+    </Stack>
   );
 }

--- a/frontend/src/modules/functional/modules/FileStorage/submodules/MediaSection.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/submodules/MediaSection.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
 import MediaThumbnail from "./MediaThumbnail";
-import { MediaTabContextProvider } from "../contexts/MediaTabContextProvider";
 
 import Stack from "@mui/material/Stack";
 interface MediaSectionProps {

--- a/frontend/src/modules/functional/modules/FileStorage/submodules/MediaThumbnail.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/submodules/MediaThumbnail.tsx
@@ -5,6 +5,8 @@ import Grid from "@mui/material/Grid";
 import Stack from "@mui/material/Stack";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import IconButton from "@mui/material/IconButton";
+import { useMediaTabContextFunctions } from "../contexts/MediaTabContextProvider";
+import CardActionArea from "@mui/material/CardActionArea";
 
 const mediaThumbnailStyle = {
   p: 0,
@@ -17,16 +19,19 @@ const mediaThumbnailCaptionStyle = {
 };
 
 export default function MediaThumbnail() {
-  const renderPreview = () => {
+  const { openGalleryModal } = useMediaTabContextFunctions();
+
+  const renderThumbnail = () => {
     return (
-      <div
-        style={{
+      <CardActionArea
+        onClick={() => openGalleryModal("1")}
+        sx={{
           width: "100%",
           height: "100px",
           backgroundColor: "red",
           aspectRatio: "4/3",
         }}
-      ></div>
+      ></CardActionArea>
     );
   };
 
@@ -34,7 +39,7 @@ export default function MediaThumbnail() {
     <>
       <Grid item sx={{ width: "200px", aspectRatio: "4/3" }}>
         <Card sx={mediaThumbnailStyle}>
-          {renderPreview()}
+          {renderThumbnail()}
           <Stack
             direction={"row"}
             alignItems={"center"}

--- a/frontend/src/modules/functional/modules/FileStorage/submodules/MediaThumbnail.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/submodules/MediaThumbnail.tsx
@@ -5,7 +5,7 @@ import Grid from "@mui/material/Grid";
 import Stack from "@mui/material/Stack";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import IconButton from "@mui/material/IconButton";
-import { useMediaTabContextFunctions } from "../contexts/MediaTabContextProvider";
+import { useMediaTabContext } from "../contexts/MediaTabContextProvider";
 import CardActionArea from "@mui/material/CardActionArea";
 
 const mediaThumbnailStyle = {
@@ -19,7 +19,7 @@ const mediaThumbnailCaptionStyle = {
 };
 
 export default function MediaThumbnail() {
-  const { openGalleryModal } = useMediaTabContextFunctions();
+  const { openGalleryModal } = useMediaTabContext();
 
   const renderThumbnail = () => {
     return (

--- a/frontend/src/modules/functional/modules/FileStorage/tabs/PhotosAndVideosTab.tsx
+++ b/frontend/src/modules/functional/modules/FileStorage/tabs/PhotosAndVideosTab.tsx
@@ -3,20 +3,23 @@ import Grid from "@mui/material/Grid";
 import MediaSection from "../submodules/MediaSection";
 import Typography from "@mui/material/Typography";
 import GalleryModal from "../submodules/GalleryModal";
+import { MediaTabContextProvider } from "../contexts/MediaTabContextProvider";
 
 export default function PhotosAndVideosTab() {
   return (
-    <>
-      <Typography>Sorted by Upload Date</Typography>
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
-          <MediaSection name={"Jul 31"} />
+    <MediaTabContextProvider>
+      <>
+        <Typography>Sorted by Upload Date</Typography>
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={6}>
+            <MediaSection name={"Jul 31"} />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <MediaSection name={"Jul 30"} />
+          </Grid>
         </Grid>
-        <Grid item xs={12} md={6}>
-          <MediaSection name={"Jul 30"} />
-        </Grid>
-      </Grid>
-      <GalleryModal />
-    </>
+        <GalleryModal />
+      </>
+    </MediaTabContextProvider>
   );
 }


### PR DESCRIPTION
## What changes are included and why?

- Add context ('global' state) to PhotosAndVideosTab
  - Controls the gallery modal state, preventing prop drilling

## How were the changes tested?

1. Navigated to the Media (photos and videos) tab: sidebar > File Storage > Photos
2. Clicked on a photo thumbnail (placeholder) and observed Gallery modal opening and closing

## What new tests are added?

N/A

## Related issues or discussions

N/A


https://user-images.githubusercontent.com/55649534/182220837-4c473452-2b2c-4dea-91c0-259dd049a14a.mov